### PR TITLE
[FEAT] 회원가입 & 로그인 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 스프링 시큐리티
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 
 	// 스프링 시큐리티
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt:0.12.6' //자바 JWT 라이브러리
+	implementation 'javax.xml.bind:jaxb-api:2.3.1' //XML 문서와 Java 객체 간 매핑 자동화
 }
 
 tasks.named('test') {

--- a/src/main/java/com/meltingpot/baeullimflower/global/config/SecurityConfig.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/config/SecurityConfig.java
@@ -1,0 +1,73 @@
+package com.meltingpot.baeullimflower.global.config;
+
+import com.meltingpot.baeullimflower.global.filter.JwtAuthenticationFilter;
+import com.meltingpot.baeullimflower.global.filter.JwtExceptionFilter;
+import com.meltingpot.baeullimflower.global.jwt.JwtAuthenticationProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    /* CORS 설정 */
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:3000/");
+        configuration.setAllowedMethods(List.of("*"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+
+    /* 특정 HTTP 요청에 대한 웹 기반 보안 구성 */
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationProvider jwtProvider) throws Exception {
+        return http
+                // ui가 아닌 token 인증을 할 것이므로 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable)
+                // csrf 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+                // cors 설정
+                .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
+                //인증 인가 설정
+                .authorizeHttpRequests(requests -> {
+                    /* 회원가입, 로그인 요청은 항상 접근 가능 */
+                    requests.requestMatchers("members/signup","members/login").permitAll();
+                    /* 관리자 관련 요청은 관리자 권한을 가지고 있어야지만 접근 가능 */
+                    requests.requestMatchers("admin/**").hasRole("Manager");
+                    /* 다른 모든 요청은 막기 */
+                    requests.anyRequest().authenticated();
+                })
+                // jwt를 사용하므로 sateless
+                .sessionManagement(
+                        sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
+                .build();
+    }
+
+
+    // 패스워드 인코더로 사용할 빈 등록
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/global/config/SecurityConfig.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/config/SecurityConfig.java
@@ -48,12 +48,13 @@ public class SecurityConfig {
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource()))
                 //인증 인가 설정
                 .authorizeHttpRequests(requests -> {
-                    /* 회원가입, 로그인 요청은 항상 접근 가능 */
-                    requests.requestMatchers("members/signup","members/login").permitAll();
-                    /* 관리자 관련 요청은 관리자 권한을 가지고 있어야지만 접근 가능 */
-                    requests.requestMatchers("admin/**").hasRole("Manager");
-                    /* 다른 모든 요청은 막기 */
-                    requests.anyRequest().authenticated();
+//                    /* 회원가입, 로그인 요청은 항상 접근 가능 */
+//                    requests.requestMatchers("members/signup","members/login").permitAll();
+//                    /* 관리자 관련 요청은 관리자 권한을 가지고 있어야지만 접근 가능 */
+//                    requests.requestMatchers("admin/**").hasRole("Manager");
+//                    /* 다른 모든 요청은 막기 */
+//                    requests.anyRequest().authenticated();
+                    requests.anyRequest().permitAll();
                 })
                 // jwt를 사용하므로 sateless
                 .sessionManagement(

--- a/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,52 @@
+package com.meltingpot.baeullimflower.global.filter;
+
+import com.meltingpot.baeullimflower.global.jwt.JwtAuthenticationProvider;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtAuthenticationProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        // 요청 헤더의 Authorization 키 값 조회
+        String authorizationHeader = request.getHeader("Authorization");
+
+        // 가져온 값에서 Bearer 제거
+        String token = getAccessToken(authorizationHeader);
+
+        if(!ObjectUtils.isEmpty(token)){
+            // 토큰이 유효한 경우 인증정보 설정
+            if(jwtProvider.isTokenValid(token)){
+                Authentication authentication = jwtProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(String authorizationHeader){
+        /* Token이 null이 아니고 Bearer로 시작해야지 정상적인 Token임 */
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")){
+            /* 정상적인 토큰이라면 앞에 Bearer 제거 후 리턴 */
+            return authorizationHeader.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.meltingpot.baeullimflower.global.filter;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain) throws ServletException, IOException {
+        try {
+            chain.doFilter(req, res);
+        } catch (JwtException ex) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, "INVALID_TOKEN", ex.getMessage());
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse res, String code, String message) throws IOException {
+        res.setStatus(status.value());
+        res.setContentType("application/json; charset=UTF-8");
+
+        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(status, code, message);
+        res.getWriter().write(jwtExceptionResponse.convertToJson());
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtExceptionResponse.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/filter/JwtExceptionResponse.java
@@ -1,0 +1,22 @@
+package com.meltingpot.baeullimflower.global.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class JwtExceptionResponse {
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public String convertToJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/global/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,87 @@
+package com.meltingpot.baeullimflower.global.jwt;
+
+import com.meltingpot.baeullimflower.member.domain.Member;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider {
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(Member member, Duration expiredAt){
+        Date now = new Date();
+        return makeToken(member, new Date(now.getTime() + expiredAt.toMillis()));
+    }
+
+    // 토큰 생성
+    public String makeToken(Member member, Date expiredAt){
+        Date now = new Date();
+
+        return Jwts.builder()
+                // 헤더 - 토큰 타입(typ): JWT
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                // 내용 - 토큰 발급자(iss): properties에서 설정한 값
+                .setIssuer(jwtProperties.getIssuer())
+                // 내용 - 토큰이 발급된 시간(iat): 현재시간
+                .setIssuedAt(now)
+                // 내용 - 토큰 만료 시간(exp): expiry 멤버 변수값
+                .setExpiration(expiredAt)
+                // 내용 - 토큰 제목(sub): 사용자 학번
+                .setSubject(member.getStudentNum())
+                // 내용 - 클레임 role: 사용자 권한
+                .claim("role", member.getRole().toString())
+                // 내용 - 클레임 id: 사용자 id
+                .claim("id",member.getMemberId())
+                // 서명: 비밀값과 함께 해시값을 HS256 방식으로 암호화
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretkey())
+                .compact();
+    }
+
+    // 토큰 유효성 검증
+    public boolean isTokenValid(String token){
+        try{
+            // secretKey를 사용해 토큰 복호화
+            Jwts.parser()
+                    .setSigningKey(jwtProperties.getSecretkey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException e){
+            // 복호화 과정에서 에러가 나면 유효하지 않은 토큰 -> JwtException 던지기
+            throw new JwtException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    // 토큰 기반으로 인증정보 가져오기
+    public Authentication getAuthentication(String token){
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(
+                new SimpleGrantedAuthority("ROLE_" + claims.get("role")));
+        return new UsernamePasswordAuthenticationToken(new User(claims.getSubject(),"",authorities),"",authorities);
+    }
+
+    // 클레임 가져오기
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretkey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    // 토큰 만료 날짜 가져오기
+    public Date getExpirationDate(String token){
+        return getClaims(token).getExpiration();
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/global/jwt/JwtProperties.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package com.meltingpot.baeullimflower.global.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@Component
+// .yml 파일에 있는 property를 자바 클래스에 값을 가져와서(바인딩) 사용할 수 있게 해주는 어노테이션
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private String issuer;
+    private String secretkey;
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
@@ -1,24 +1,34 @@
 package com.meltingpot.baeullimflower.member.controller;
 
+import com.meltingpot.baeullimflower.member.dto.LoginRequestDto;
+import com.meltingpot.baeullimflower.member.dto.LoginResponseDto;
 import com.meltingpot.baeullimflower.member.dto.SignupRequestDto;
 import com.meltingpot.baeullimflower.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
+    // 테스트
+    @GetMapping("/test")
+    public String test() {
+        return "test";
+    }
 
     // 회원가입
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignupRequestDto requestDto){
         return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다. memberid: " + memberService.signup(requestDto));
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto){
+        return ResponseEntity.status(HttpStatus.OK).body(memberService.login(requestDto));
     }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
@@ -1,0 +1,24 @@
+package com.meltingpot.baeullimflower.member.controller;
+
+import com.meltingpot.baeullimflower.member.dto.SignupRequestDto;
+import com.meltingpot.baeullimflower.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+    private final MemberService memberService;
+
+    // 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody SignupRequestDto requestDto){
+        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다. memberid: " + memberService.signup(requestDto));
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.meltingpot.baeullimflower.member.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +29,13 @@ public class Member{
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Builder
+    public Member(String name, String studentNum, College college, String password, Role role) {
+        this.name = name;
+        this.studentNum = studentNum;
+        this.college = college;
+        this.password = password;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/member/dto/LoginRequestDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/dto/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package com.meltingpot.baeullimflower.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequestDto {
+    private String studentNum;
+    private String password;
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/dto/LoginResponseDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/dto/LoginResponseDto.java
@@ -1,0 +1,19 @@
+package com.meltingpot.baeullimflower.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public LoginResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/dto/SignupRequestDto.java
@@ -1,0 +1,14 @@
+package com.meltingpot.baeullimflower.member.dto;
+
+import com.meltingpot.baeullimflower.member.domain.College;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+    private String name;
+    private String studentNum;
+    private College college;
+    private String password;
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/dto/SignupRequestDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/dto/SignupRequestDto.java
@@ -1,14 +1,24 @@
 package com.meltingpot.baeullimflower.member.dto;
 
 import com.meltingpot.baeullimflower.member.domain.College;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignupRequestDto {
+    @NotBlank(message = "이름은 필수로 입력되어야 합니다.") //해당 값이 null이 아니고, 공백(""과 " " 모두 포함)이 아닌지 검증
     private String name;
+
+    @NotBlank(message = "학번은 필수로 입력되어야 합니다.")
     private String studentNum;
+
+    @NotBlank(message = "단과대학은 필수로 입력되어야 합니다.")
     private College college;
+
+    @NotBlank(message = "비밀번호는 필수로 입력되어야 합니다.")
     private String password;
 }

--- a/src/main/java/com/meltingpot/baeullimflower/member/repository/MemberRepository.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/repository/MemberRepository.java
@@ -3,7 +3,12 @@ package com.meltingpot.baeullimflower.member.repository;
 import com.meltingpot.baeullimflower.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     // 학번 중복 체크
     Boolean existsByStudentNum(String studentNum);
+
+    // 학번으로 Member 찾기
+    Member findByStudentNum(String studentNum);
 }

--- a/src/main/java/com/meltingpot/baeullimflower/member/repository/MemberRepository.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.meltingpot.baeullimflower.member.repository;
+
+import com.meltingpot.baeullimflower.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    // 학번 중복 체크
+    Boolean existsByStudentNum(String studentNum);
+}

--- a/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
@@ -8,6 +8,9 @@ import com.meltingpot.baeullimflower.member.dto.LoginResponseDto;
 import com.meltingpot.baeullimflower.member.dto.SignupRequestDto;
 import com.meltingpot.baeullimflower.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,6 +65,15 @@ public class MemberService {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    // 현재 인증된(로그인한) 유저의 id를 찾아 반환
+    public static Long getCurrentMemberId(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || authentication.getName() == null){
+            throw new AuthenticationServiceException("인증된 사용자정보가 없습니다.");
+        }
+        return Long.valueOf(authentication.getName());
     }
 
 

--- a/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
@@ -56,7 +56,7 @@ public class MemberService {
         - 액세스토큰: 30분
         - 리프레시토큰: 7일
         */
-        String accessToken = jwtProvider.generateToken(member, Duration.ofMinutes(1));
+        String accessToken = jwtProvider.generateToken(member, Duration.ofMinutes(30));
         String refreshToken = jwtProvider.generateToken(member, Duration.ofDays(7));
 
         // 리프레시 토큰 저장

--- a/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
@@ -1,0 +1,42 @@
+package com.meltingpot.baeullimflower.member.service;
+
+import com.meltingpot.baeullimflower.member.domain.Member;
+import com.meltingpot.baeullimflower.member.domain.Role;
+import com.meltingpot.baeullimflower.member.dto.SignupRequestDto;
+import com.meltingpot.baeullimflower.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    // 회원가입
+    public Long signup(SignupRequestDto requestDto){
+        // 학번 중복 체크
+        if(existsByStudentNum(requestDto.getStudentNum())){
+            throw new RuntimeException("이미 존재하는 학번입니다.");
+        }
+
+        // 중복되지 않는다면 저장
+        return memberRepository.save(Member.builder()
+                .name(requestDto.getName())
+                .studentNum(requestDto.getStudentNum())
+                .college(requestDto.getCollege())
+                .password(bCryptPasswordEncoder.encode(requestDto.getPassword())) //패스워드 암호화
+                .role(Role.User)
+                .build()).getMemberId();
+    }
+
+    /* Transactional 함수들 */
+
+    // 학번 중복 체크
+    @Transactional(readOnly = true)
+    public Boolean existsByStudentNum(String studentNum){
+        return memberRepository.existsByStudentNum(studentNum);
+    }
+}


### PR DESCRIPTION
# 구현 기능
- 회원가입
- 로그인
- 액세스토큰, 리프레시토큰 발급
- 토큰 만료 예외처리

# 구현 상태
- 회원가입
![image](https://github.com/user-attachments/assets/1dae4978-4d75-42cb-9654-900b051c6315)

- 로그인
![스크린샷 2024-09-14 011355](https://github.com/user-attachments/assets/e05b8be4-0bd3-4f8f-a0d0-7830753baf5a)

- 유효한 토큰 사용시
![스크린샷 2024-09-14 011423](https://github.com/user-attachments/assets/941bc6be-a1f9-4f68-b0b1-5dc665962ef0)

- 유효하지 않은(만료된) 토큰 사용시
![image](https://github.com/user-attachments/assets/4f62da0a-3b2f-4354-b148-2ab8521ed750)

# 참고
- 리프레시토큰 저장 및 액세스토큰 재발급 구현 필요
- 현재 개발을 위해 모든 api 인증 해제해둠 -> 개발 완료 후 회원가입, 로그인, 액세스토큰 재발급 제외하고 모두 막기!, 관리자 관련 요청 막기!
- MemberService.getCurrentMemberId() 메서드를 통해 현재 로그인한 사용자의 id 가져올 수 있음

# Resolve
- #5 
