### PR TITLE
[refactor] 청원 API 분리 - 이메일, 정보 동의 / 청원 내용

### DIFF
--- a/src/main/java/com/meltingpot/baeullimflower/post/controller/PostController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/controller/PostController.java
@@ -1,9 +1,11 @@
 package com.meltingpot.baeullimflower.post.controller;
 
+import com.meltingpot.baeullimflower.global.apiResponse.ApiResponse;
 import com.meltingpot.baeullimflower.post.domain.Post;
 import com.meltingpot.baeullimflower.post.dto.PostRequestDto;
 import com.meltingpot.baeullimflower.post.dto.PostResponseDto;
 import com.meltingpot.baeullimflower.post.service.PostService;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -14,14 +16,25 @@ import org.springframework.web.bind.annotation.*;
 public class PostController {
     private final PostService postService;
 
+    @PostMapping("/pre")
+    public ApiResponse<PostResponseDto.PostPreDto> prePost(@RequestBody @Valid PostRequestDto.PostPreDto request, HttpSession session) {
+        session.setAttribute("email", request.getEmail());
+        session.setAttribute("infoAgree", request.getInfoAgree());
+        return ApiResponse.onSuccess(postService.prePost(request));
+    }
+
     @PostMapping("")
-    public Post createPost(@RequestBody @Valid PostRequestDto.PostCreateDto request) {
-        return postService.createPost(request);
+    public ApiResponse<PostResponseDto.PostDto> createPost(@RequestBody @Valid PostRequestDto.PostCreateDto request, HttpSession session) {
+        String email = (String)session.getAttribute("email");
+        Boolean infoAgree = (Boolean)session.getAttribute("infoAgree");
+        request.setEmail(email);
+        request.setInfoAgree(infoAgree);
+        return ApiResponse.onSuccess(postService.createPost(request));
     }
 
     @GetMapping("")
-    public PostResponseDto.PostDto getPostDetail(@RequestParam Long postId) {
-        return postService.getPostDetail(postId);
+    public ApiResponse<PostResponseDto.PostDto> getPostDetail(@RequestParam Long postId) {
+        return ApiResponse.onSuccess(postService.getPostDetail(postId));
     }
 
 }

--- a/src/main/java/com/meltingpot/baeullimflower/post/converter/PostConverter.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/converter/PostConverter.java
@@ -27,7 +27,7 @@ public class PostConverter {
 
         post.updateUrlList(request.getUrlList());
         return post;
-        }
+    }
 
 
     public PostResponseDto.PostDto toPostDto(Post post) {
@@ -41,7 +41,6 @@ public class PostConverter {
                 .postId(post.getPostId())
                 .status(post.getStatus())
                 .writer(post.getWriter())
-                .email(post.getEmail())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .categrory(post.getCategrory())

--- a/src/main/java/com/meltingpot/baeullimflower/post/dto/PostRequestDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/dto/PostRequestDto.java
@@ -15,5 +15,17 @@ public class PostRequestDto {
         private String content;
         private Categrory categrory;
         List<String> urlList;
+        public void setEmail(String email) {
+            this.email = email;
+        }
+        public void setInfoAgree(Boolean infoAgree) {
+            this.infoAgree = infoAgree;
+        }
+    }
+
+    @Getter
+    public static class PostPreDto {
+        private String email;
+        private Boolean infoAgree;
     }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/post/dto/PostResponseDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/dto/PostResponseDto.java
@@ -24,8 +24,6 @@ public class PostResponseDto {
         private Long postId;
         private Member writer;
 
-        private String email;
-
         private Status status;
         private String title;
         private String content;
@@ -38,4 +36,14 @@ public class PostResponseDto {
 
         List<String> urlList;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostPreDto {
+        private String email;
+        private Boolean infoAgree;
+    }
+
 }

--- a/src/main/java/com/meltingpot/baeullimflower/post/service/PostService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/service/PostService.java
@@ -1,5 +1,7 @@
 package com.meltingpot.baeullimflower.post.service;
 
+import com.meltingpot.baeullimflower.global.apiResponse.code.status.ErrorStatus;
+import com.meltingpot.baeullimflower.global.apiResponse.exception.GeneralException;
 import com.meltingpot.baeullimflower.post.Repository.PostRepository;
 import com.meltingpot.baeullimflower.post.converter.PostConverter;
 import com.meltingpot.baeullimflower.post.domain.Post;
@@ -16,25 +18,31 @@ public class PostService {
     private final PostConverter postConverter;
     private final PostRepository postRepository;
     @Transactional
-    public Post createPost(PostRequestDto.PostCreateDto request) {
-        if (request.getEmail() == null || request.getEmail().isEmpty()) {
-        //GeneralException -> EMAIL_REQUIRED
-        }
-
-        // 동의하지 않은 경우 예외 처리
-        if (request.getInfoAgree() == null || !request.getInfoAgree()) {
-        //GeneralException -> INFOAGREE_REQUIRED
-        }
-
+    public PostResponseDto.PostDto createPost(PostRequestDto.PostCreateDto request) {
         Post post = postConverter.toPostEntity(request);
         postRepository.save(post);
+        PostResponseDto.PostDto postDto = postConverter.toPostDto(post);
 
-        return post;
+        return postDto;
+    }
+
+    public PostResponseDto.PostPreDto prePost(PostRequestDto.PostPreDto request) {
+        String email = request.getEmail();
+        Boolean infoAgree = request.getInfoAgree();
+
+        if (email == null || email.isEmpty()) {
+            throw new GeneralException(ErrorStatus.EMAIL_REQUIRED);
+        }
+        if (infoAgree == null || !infoAgree) {
+            throw new GeneralException(ErrorStatus.AGREE_REQUIRED);
+        }
+
+        PostResponseDto.PostPreDto postPreDto = new PostResponseDto.PostPreDto(email, infoAgree);
+        return postPreDto;
     }
 
     public Post findById(Long postId){
-        return postRepository.findById(postId).orElseThrow(()->new RuntimeException());
-        // 해당 게시물 없을 경우 에러처리 -> GeneralException(POST_NOT_FOUND)
+        return postRepository.findById(postId).orElseThrow(()->new GeneralException(ErrorStatus.POST_NOT_FOUND));
     }
 
     public PostResponseDto.PostDto getPostDetail(Long postId){


### PR DESCRIPTION
# 구현 기능
- Post API 분리 -> 청원자 이메일, 정보 동의 / 청원 내용 기입 분리

# 구현 상태
-  청원자 이메일, 정보 동의 / 청원 내용 기입 API 분리
- POST_NOT_FOUND 예외 처리
