### PR TITLE
[REFACTOR] 회원가입/로그인 성공 및 예외 처리

### DIFF
--- a/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
@@ -19,11 +19,12 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // 멤버 관련 에러
-    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 이메일 입니다."),
-    INVALID_USER(HttpStatus.BAD_REQUEST, "MEMBER4004", "유효하지 않은 사용자 입니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4005", "유효하지 않은 리프레시 토큰 입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "인증된 사용자 정보가 없습니다."),
+    ALREADY_EXIST_STUDENTNUM(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 존재하는 학번 입니다."),
+    NOT_EXIST_STUDENTNUM(HttpStatus.BAD_REQUEST, "MEMBER4003", "존재하지 않는 학번 입니다."),
+    MISMATCH_PASSWORD(HttpStatus.BAD_REQUEST, "MEMBER4004", "비밀번호가 일치하지 않습니다."),
+    INVALID_USER(HttpStatus.BAD_REQUEST, "MEMBER4005", "유효하지 않은 사용자 입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER4006", "유효하지 않은 리프레시 토큰 입니다."),
     // 게시물 관련 에러
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
     EMAIL_REQUIRED(HttpStatus.FORBIDDEN,"EMAIL4003","이메일을 입력해주세요"),

--- a/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/controller/MemberController.java
@@ -1,12 +1,11 @@
 package com.meltingpot.baeullimflower.member.controller;
 
+import com.meltingpot.baeullimflower.global.apiResponse.ApiResponse;
 import com.meltingpot.baeullimflower.member.dto.LoginRequestDto;
 import com.meltingpot.baeullimflower.member.dto.LoginResponseDto;
 import com.meltingpot.baeullimflower.member.dto.SignupRequestDto;
 import com.meltingpot.baeullimflower.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,18 +16,19 @@ public class MemberController {
     // 테스트
     @GetMapping("/test")
     public String test() {
+        Long memberid = MemberService.getCurrentMemberId();
         return "test";
     }
 
     // 회원가입
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@RequestBody SignupRequestDto requestDto){
-        return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다. memberid: " + memberService.signup(requestDto));
+    public ApiResponse<String> signup(@RequestBody SignupRequestDto requestDto){
+        return ApiResponse.onCreateSuccess("회원가입이 완료되었습니다. memberId: "+ memberService.signup(requestDto));
     }
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto){
-        return ResponseEntity.status(HttpStatus.OK).body(memberService.login(requestDto));
+    public ApiResponse<LoginResponseDto> login(@RequestBody LoginRequestDto requestDto){
+        return ApiResponse.onSuccess(memberService.login(requestDto));
     }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
@@ -1,10 +1,13 @@
 package com.meltingpot.baeullimflower.member.domain;
 
+import com.meltingpot.baeullimflower.vote.domain.Vote;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +32,9 @@ public class Member{
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<Vote> voteList;
 
     @Builder
     public Member(String name, String studentNum, College college, String password, Role role) {

--- a/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.meltingpot.baeullimflower.member.service;
 
+import com.meltingpot.baeullimflower.global.apiResponse.code.status.ErrorStatus;
+import com.meltingpot.baeullimflower.global.apiResponse.exception.GeneralException;
 import com.meltingpot.baeullimflower.global.jwt.JwtAuthenticationProvider;
 import com.meltingpot.baeullimflower.member.domain.Member;
 import com.meltingpot.baeullimflower.member.domain.Role;
@@ -28,7 +30,7 @@ public class MemberService {
     public Long signup(SignupRequestDto requestDto){
         // 학번 중복 체크
         if(existsByStudentNum(requestDto.getStudentNum())){
-            throw new RuntimeException("이미 존재하는 학번입니다.");
+            throw new GeneralException(ErrorStatus.ALREADY_EXIST_STUDENTNUM);
         }
 
         // 중복되지 않는다면 저장
@@ -46,9 +48,14 @@ public class MemberService {
         // 사용자 가져오기
         Member member = findByStudentNum(requestDto.getStudentNum());
 
+        // 학번 존재 여부 확인
+        if(member == null){
+            throw new GeneralException(ErrorStatus.NOT_EXIST_STUDENTNUM);
+        }
+
         // 비밀번호 일치여부 확인
         if(!bCryptPasswordEncoder.matches(requestDto.getPassword(), member.getPassword())){
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new GeneralException(ErrorStatus.MISMATCH_PASSWORD);
         }
 
         /*
@@ -71,7 +78,8 @@ public class MemberService {
     public static Long getCurrentMemberId(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication == null || authentication.getName() == null){
-            throw new AuthenticationServiceException("인증된 사용자정보가 없습니다.");
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+//            throw new AuthenticationServiceException("인증된 사용자정보가 없습니다.");
         }
         return Long.valueOf(authentication.getName());
     }


### PR DESCRIPTION
# 구현 기능
- 회원가입/로그인 성공 및 예외처리

# 구현 상태
- 회원가입
    - 성공처리:  ApiResponse.onCreateSuccess 응답
    - 예외처리: 학번 중복 시 ALREADY_EXIST_STUDENTNUM 에러 반환
- 로그인
    - 성공처리:  ApiResponse.onSuccess 응답
    - 예외처리: 학번이 존재하지 않을 시 NOT_EXIST_STUDENTNUM 에러 반환, 비밀번호가 일치하지 않을 시 MISMATCH_PASSWORD 에러 반환
- 현재 인증된 유저의 id 반환
    - 예외처리: 인증된 사용자 정보가 없을 시 MEMBER_NOT_FOUND 에러 반환

# Resolve
- #5 