### PR TITLE
[FEAT] 청원 논의 결과 API

### DIFF
--- a/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
@@ -30,9 +30,12 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
     EMAIL_REQUIRED(HttpStatus.FORBIDDEN,"EMAIL4003","이메일을 입력해주세요"),
     AGREE_REQUIRED(HttpStatus.FORBIDDEN, "AGREE4003","정보 동의해주세요"),
-    PAGE_FORMAT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"PAGE4001","잘못된 페이지 번호 형식입니다");
+    PAGE_FORMAT_BAD_REQUEST(HttpStatus.BAD_REQUEST,"PAGE4001","잘못된 페이지 번호 형식입니다"),
 
     // 투표 관련 에러
+
+    // 결과 관련 에러
+    ALREADY_EXIST_RESULT(HttpStatus.BAD_REQUEST, "RESULT4001", "해당 청원에 대한 논의 결과가 이미 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
+++ b/src/main/java/com/meltingpot/baeullimflower/global/apiResponse/code/status/ErrorStatus.java
@@ -35,7 +35,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // 투표 관련 에러
 
     // 결과 관련 에러
-    ALREADY_EXIST_RESULT(HttpStatus.BAD_REQUEST, "RESULT4001", "해당 청원에 대한 논의 결과가 이미 존재합니다.");
+    ALREADY_EXIST_RESULT(HttpStatus.BAD_REQUEST, "RESULT4001", "해당 청원에 대한 논의 결과가 이미 존재합니다."),
+    MUST_BE_DISCUSSION(HttpStatus.BAD_REQUEST, "RESULT4002", "청원글의 상태가 '학생회 논의중'일때만 결과를 작성할 수 있습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/domain/Member.java
@@ -21,7 +21,7 @@ public class Member{
     @Column(nullable = false, length = 16)
     private String name;
 
-    @Column(name = "stu_num", nullable = false, length = 16)
+    @Column(name = "student_num", nullable = false, length = 16)
     private String studentNum;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/member/service/MemberService.java
@@ -75,13 +75,13 @@ public class MemberService {
     }
 
     // 현재 인증된(로그인한) 유저의 id를 찾아 반환
-    public static Long getCurrentMemberId(){
+    public static String getCurrentMemberId(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if(authentication == null || authentication.getName() == null){
             throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
 //            throw new AuthenticationServiceException("인증된 사용자정보가 없습니다.");
         }
-        return Long.valueOf(authentication.getName());
+        return authentication.getName();
     }
 
 

--- a/src/main/java/com/meltingpot/baeullimflower/post/service/PostStatusScheduler.java
+++ b/src/main/java/com/meltingpot/baeullimflower/post/service/PostStatusScheduler.java
@@ -1,5 +1,7 @@
 package com.meltingpot.baeullimflower.post.service;
 
+import com.meltingpot.baeullimflower.global.apiResponse.code.status.ErrorStatus;
+import com.meltingpot.baeullimflower.global.apiResponse.exception.GeneralException;
 import com.meltingpot.baeullimflower.post.Repository.PostRepository;
 import com.meltingpot.baeullimflower.post.domain.Post;
 import com.meltingpot.baeullimflower.post.domain.Status;
@@ -35,6 +37,15 @@ public class PostStatusScheduler {
             }
             postRepository.save(post);
         }
+    }
+
+    @Transactional
+    public void updatePostConclusion(Post post){
+        if(!post.getStatus().equals(Status.DISCUSSION)){
+            throw new GeneralException(ErrorStatus.MUST_BE_DISCUSSION);
+        }
+        post.updateStatus(Status.CONCLUSION);
+        postRepository.save(post);
     }
 }
 

--- a/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
@@ -1,0 +1,21 @@
+package com.meltingpot.baeullimflower.result.controller;
+
+import com.meltingpot.baeullimflower.global.apiResponse.ApiResponse;
+import com.meltingpot.baeullimflower.result.dto.ResultRequestDto;
+import com.meltingpot.baeullimflower.result.dto.ResultResponseDto;
+import com.meltingpot.baeullimflower.result.service.ResultService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor // 초기화되지 않은 final 필드나 @NotNull이 붙은 필드에 대해 생성자를 생성해줌
+public class ResultController {
+    private final ResultService resultService;
+
+    @PostMapping("/{postId}/result")
+    public ResultResponseDto createResult(@PathVariable Long postId, @RequestBody ResultRequestDto requestDto){
+        return ApiResponse.onCreateSuccess(resultService.createResult(postId,requestDto)).getResult();
+    }
+
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class ResultController {
     private final ResultService resultService;
 
+    // 논의결과 작성
     @PostMapping("/{postId}/result")
     public ResultResponseDto createResult(@PathVariable Long postId, @RequestBody ResultRequestDto requestDto){
         return ApiResponse.onCreateSuccess(resultService.createResult(postId,requestDto)).getResult();

--- a/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/controller/ResultController.java
@@ -8,15 +8,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/admin")
+@RequestMapping
 @RequiredArgsConstructor // 초기화되지 않은 final 필드나 @NotNull이 붙은 필드에 대해 생성자를 생성해줌
 public class ResultController {
     private final ResultService resultService;
 
     // 논의결과 작성
-    @PostMapping("/{postId}/result")
+    @PostMapping("admin/{postId}/result")
     public ResultResponseDto createResult(@PathVariable Long postId, @RequestBody ResultRequestDto requestDto){
         return ApiResponse.onCreateSuccess(resultService.createResult(postId,requestDto)).getResult();
     }
+
+    // 논의결과 조회
+    @GetMapping("/{postId}/result")
+    public ResultResponseDto getResult(@PathVariable Long postId){
+        return ApiResponse.onSuccess(resultService.getResult(postId)).getResult();
+    }
+
 
 }

--- a/src/main/java/com/meltingpot/baeullimflower/result/converter/ResultConverter.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/converter/ResultConverter.java
@@ -1,0 +1,32 @@
+package com.meltingpot.baeullimflower.result.converter;
+
+import com.meltingpot.baeullimflower.member.domain.Member;
+import com.meltingpot.baeullimflower.post.domain.Post;
+import com.meltingpot.baeullimflower.result.domain.Result;
+import com.meltingpot.baeullimflower.result.dto.ResultRequestDto;
+import com.meltingpot.baeullimflower.result.dto.ResultResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResultConverter {
+    public Result toResultEntity(ResultRequestDto requestDto, Member member, Post post) {
+        Result result = Result.builder()
+                .content(requestDto.getContent())
+                .manager(member)
+                .post(post)
+                .build();
+        return result;
+    }
+
+    public ResultResponseDto toResultDto(Result result) {
+        ResultResponseDto resultDto = ResultResponseDto.builder()
+                .postId(result.getPost().getPostId())
+                .resultId(result.getResultId())
+                .result(result.getContent())
+                .createdAt(result.getCreatedDate())
+                .build();
+        return resultDto;
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/domain/Result.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/domain/Result.java
@@ -6,6 +6,7 @@ import com.meltingpot.baeullimflower.member.domain.Member;
 import com.meltingpot.baeullimflower.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +29,11 @@ public class Result extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", updatable = false)
     private Member manager;
+
+    @Builder
+    public Result(String content, Post post, Member manager) {
+        this.content = content;
+        this.post = post;
+        this.manager = manager;
+    }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/result/dto/ResultRequestDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/dto/ResultRequestDto.java
@@ -1,0 +1,13 @@
+package com.meltingpot.baeullimflower.result.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 파라미터가 없는 디폴트 생성자를 자동으로 생성
+public class ResultRequestDto {
+    @NotNull(message = "내용은 필수로 입력되어야 합니다.") // 공백까지는 허용
+    private String content;
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/dto/ResultResponseDto.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/dto/ResultResponseDto.java
@@ -1,0 +1,22 @@
+package com.meltingpot.baeullimflower.result.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ResultResponseDto {
+    private Long postId;
+    private Long resultId;
+    private String result;
+    private LocalDateTime createdAt;
+
+    @Builder
+    public ResultResponseDto(Long postId, Long resultId, String result, LocalDateTime createdAt) {
+        this.postId = postId;
+        this.resultId = resultId;
+        this.result = result;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/repository/ResultRepository.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/repository/ResultRepository.java
@@ -1,0 +1,8 @@
+package com.meltingpot.baeullimflower.result.repository;
+
+import com.meltingpot.baeullimflower.result.domain.Result;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ResultRepository extends JpaRepository<Result, Long> {
+    Boolean existsByPost_PostId(Long postId);
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/repository/ResultRepository.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/repository/ResultRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ResultRepository extends JpaRepository<Result, Long> {
     Boolean existsByPost_PostId(Long postId);
+
+    Result findByPost_PostId(Long postId);
 }

--- a/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
@@ -25,7 +25,7 @@ public class ResultService {
 
     public ResultResponseDto createResult(Long postId, ResultRequestDto requestDto) {
         // 결과를 작성한 관리자 및 청원글 가져오기
-        Member manager = memberService.findByStudentNum(MemberService.getCurrentMemberId().toString());
+        Member manager = memberService.findByStudentNum(MemberService.getCurrentMemberId());
         Post post = postService.findById(postId);
 
         // 결과가 이미 작성된 청원글인지 확인

--- a/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
@@ -6,6 +6,7 @@ import com.meltingpot.baeullimflower.member.domain.Member;
 import com.meltingpot.baeullimflower.member.service.MemberService;
 import com.meltingpot.baeullimflower.post.domain.Post;
 import com.meltingpot.baeullimflower.post.service.PostService;
+import com.meltingpot.baeullimflower.post.service.PostStatusScheduler;
 import com.meltingpot.baeullimflower.result.converter.ResultConverter;
 import com.meltingpot.baeullimflower.result.domain.Result;
 import com.meltingpot.baeullimflower.result.dto.ResultRequestDto;
@@ -22,6 +23,7 @@ public class ResultService {
     private final MemberService memberService;
     private final ResultConverter resultConverter;
     private final ResultRepository resultRepository;
+    private final PostStatusScheduler postStatusScheduler;
 
     public ResultResponseDto createResult(Long postId, ResultRequestDto requestDto) {
         // 결과를 작성한 관리자 및 청원글 가져오기
@@ -32,6 +34,9 @@ public class ResultService {
         if(existsByPostId(postId)){
             throw new GeneralException(ErrorStatus.ALREADY_EXIST_RESULT);
         }
+
+        // 해당 청원글 종료로 변경
+        postStatusScheduler.updatePostConclusion(post);
 
         // 결과 객체 생성 및 저장
         Result result = resultConverter.toResultEntity(requestDto, manager, post);

--- a/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
@@ -1,0 +1,48 @@
+package com.meltingpot.baeullimflower.result.service;
+
+import com.meltingpot.baeullimflower.global.apiResponse.code.status.ErrorStatus;
+import com.meltingpot.baeullimflower.global.apiResponse.exception.GeneralException;
+import com.meltingpot.baeullimflower.member.domain.Member;
+import com.meltingpot.baeullimflower.member.service.MemberService;
+import com.meltingpot.baeullimflower.post.domain.Post;
+import com.meltingpot.baeullimflower.post.service.PostService;
+import com.meltingpot.baeullimflower.result.converter.ResultConverter;
+import com.meltingpot.baeullimflower.result.domain.Result;
+import com.meltingpot.baeullimflower.result.dto.ResultRequestDto;
+import com.meltingpot.baeullimflower.result.dto.ResultResponseDto;
+import com.meltingpot.baeullimflower.result.repository.ResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor// 초기화되지 않은 final 필드나 @NotNull이 붙은 필드에 대해 생성자를 생성해줌
+public class ResultService {
+    private final PostService postService;
+    private final MemberService memberService;
+    private final ResultConverter resultConverter;
+    private final ResultRepository resultRepository;
+
+    public ResultResponseDto createResult(Long postId, ResultRequestDto requestDto) {
+        // 결과를 작성한 관리자 및 청원글 가져오기
+        Member manager = memberService.findByStudentNum(MemberService.getCurrentMemberId().toString());
+        Post post = postService.findById(postId);
+
+        // 결과가 이미 작성된 청원글인지 확인
+        if(existsByPostId(postId)){
+            throw new GeneralException(ErrorStatus.ALREADY_EXIST_RESULT);
+        }
+
+        // 결과 객체 생성 및 저장
+        Result result = resultConverter.toResultEntity(requestDto, manager, post);
+        resultRepository.save(result);
+
+        return resultConverter.toResultDto(result);
+    }
+
+
+    @Transactional
+    public boolean existsByPostId(Long postId) {
+        return resultRepository.existsByPost_PostId(postId);
+    }
+}

--- a/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
@@ -40,11 +40,21 @@ public class ResultService {
         return resultConverter.toResultDto(result);
     }
 
+    public ResultResponseDto getResult(Long postId) {
+        Result result = findByPostId(postId);
+        return resultConverter.toResultDto(result);
+    }
+
     /* Transactional 함수들 */
 
     // 해당 청원글에 결과가 이미 작성되어 있는지 확인
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean existsByPostId(Long postId) {
         return resultRepository.existsByPost_PostId(postId);
+    }
+
+    @Transactional(readOnly = true)
+    public Result findByPostId(Long postId) {
+        return resultRepository.findByPost_PostId(postId);
     }
 }

--- a/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
+++ b/src/main/java/com/meltingpot/baeullimflower/result/service/ResultService.java
@@ -28,7 +28,7 @@ public class ResultService {
         Member manager = memberService.findByStudentNum(MemberService.getCurrentMemberId());
         Post post = postService.findById(postId);
 
-        // 결과가 이미 작성된 청원글인지 확인
+        // 해당 청원글에 결과가 이미 작성되어 있는지 확인
         if(existsByPostId(postId)){
             throw new GeneralException(ErrorStatus.ALREADY_EXIST_RESULT);
         }
@@ -40,7 +40,9 @@ public class ResultService {
         return resultConverter.toResultDto(result);
     }
 
+    /* Transactional 함수들 */
 
+    // 해당 청원글에 결과가 이미 작성되어 있는지 확인
     @Transactional
     public boolean existsByPostId(Long postId) {
         return resultRepository.existsByPost_PostId(postId);


### PR DESCRIPTION
# 구현 기능
- 청원 논의 결과 작성 및 조회

# 구현 상태
- 청원 논의 결과 작성(성공)
![스크린샷 2024-10-01 203024](https://github.com/user-attachments/assets/1917854b-3d77-417a-9e5d-8c9bfbe92cbe)

- 청원 논의 결과 작성(실패: 이미 결과가 존재하는 경우)
![스크린샷 2024-10-01 210334](https://github.com/user-attachments/assets/0c46ddb3-64af-4395-9ce0-b5af2b10bc29)

- 청원 논의 결과 작성(실패: 청원글의 상태가 '학생회 논의중'이 아닌 경우)
![스크린샷 2024-10-01 220850](https://github.com/user-attachments/assets/71131dda-a0bc-4eb4-b0e6-4e11bcee4b2a)

- 청원 논의 결과 조회
![스크린샷 2024-10-01 215013](https://github.com/user-attachments/assets/fd8dec65-e6fe-4c68-885d-e82d28023adb)

# Resolve
- #15 